### PR TITLE
feat: support blind & attended transfers

### DIFF
--- a/pkg/ari/event.go
+++ b/pkg/ari/event.go
@@ -51,3 +51,25 @@ type StasisEnd struct {
 type ChannelStateChange struct {
 	Chan Channel `json:"channel"`
 }
+
+type Bridge struct {
+	ID       string   `json:"id"`
+	Channels []string `json:"channels"`
+}
+
+type BridgeBlindTransfer struct {
+	Channel        Channel `json:"channel"`
+	Extension      string  `json:"exten"`
+	Result         string  `json:"result"`
+	Transferee     Channel `json:"transferee"`
+	ReplaceChannel Channel `json:"replace_channel"`
+}
+
+type ChannelMemberBridge struct {
+	Bridge  Bridge  `json:"bridge"`
+	Channel Channel `json:"channel"`
+}
+
+type BridgeDestroyed struct {
+	Bridge Bridge `json:"bridge"`
+}


### PR DESCRIPTION
Code is hot garbage but it does the job. The logic was changed from "To" and "From" to simply considering a call to be a connnection of channels an a bridge. This is because not all calls are of simply two participants and they may change throughout its lifetime. This also plays nicely with transfers.

Most of the transfer logic is handled by Asterisk and ARI just needs to keep track of changes in bridge membership and update accordingly so it can properly hangup calls when its time to.