### PR TITLE
Play explanatory audios before hanging up

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ This app name will need to be stated in Asterisk's dialplan to pass call control
 
 ### `CREDENTIALS`
 The username and password to authenticate with ARI. It must be in the format `username:password`.
+
+### `DEBUG`
+If true, all Stasis messages will be printed to the console.
+
+## Required sound files
+To provide a good user experience certain files are played back to the user when a call is rejected or not answered.
+The path to this files is not customizable to they need to be placed in the following locations:
+
+### `/sounds/vouncer_reject`
+Played when a call is not allowed, this can happen when the extension does not exist or the user has no permission.
+
+### `/sounds/vouncer_timeout`
+Played when the far end declines the call or the dial application times out.

--- a/pkg/ari/ari.go
+++ b/pkg/ari/ari.go
@@ -9,6 +9,7 @@ import (
 )
 
 var ErrNotFound = errors.New("resource not found")
+var ErrCallNotAllowed = errors.New("call not allowed")
 
 type Client struct {
 	Scheme      string

--- a/pkg/ari/channel.go
+++ b/pkg/ari/channel.go
@@ -119,3 +119,24 @@ func (c *Client) ChannelRing(chid string, state bool) error {
 
 	return nil
 }
+
+func (c *Client) ChannelPlay(chid string, media string) error {
+	params := url.Values{}
+	params.Set("media", media)
+
+	res, err := c.Post(
+		fmt.Sprintf("/ari/channels/%s/play", chid),
+		"",
+		&params,
+		nil,
+	)
+
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected status code %d", res.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/ari/event.go
+++ b/pkg/ari/event.go
@@ -85,3 +85,9 @@ type Playback struct {
 type PlaybackFinished struct {
 	Playback Playback `json:"playback"`
 }
+
+type ChannelDestroyed struct {
+	Cause     int     `json:"cause"`
+	CauseText string  `json:"cause_txt"`
+	Channel   Channel `json:"channel"`
+}

--- a/pkg/ari/event.go
+++ b/pkg/ari/event.go
@@ -73,3 +73,15 @@ type ChannelMemberBridge struct {
 type BridgeDestroyed struct {
 	Bridge Bridge `json:"bridge"`
 }
+
+type Playback struct {
+	ID        string `json:"id"`
+	MediaURI  string `json:"media_uri"`
+	TargetURI string `json:"target_uri"`
+	Language  string `json:"language"`
+	State     string `json:"state"`
+}
+
+type PlaybackFinished struct {
+	Playback Playback `json:"playback"`
+}


### PR DESCRIPTION
Instead of simply hanging up calls, vouncer will now play audio messages to explain the users  why the call is being terminated.